### PR TITLE
Make NAR path independent of working directory

### DIFF
--- a/misc/Python/NAR.py
+++ b/misc/Python/NAR.py
@@ -1,5 +1,6 @@
 import pexpect
-NAR = pexpect.spawn('./../../NAR shell')
+import os.path
+NAR = pexpect.spawn(os.path.join(os.path.dirname(__file__), './../../NAR shell'))
 
 def parseTruth(T):
     return {"frequency": T.split("frequency=")[1].split(" confidence")[0], "confidence": T.split(" confidence=")[1]}


### PR DESCRIPTION
I plan to use ONA for a small project through the Python API. I added ONA as a submodule and imported it like so:
`import sys`
`sys.path.append("ona/misc/Python")`
`import NAR`
This fails because spawn uses the working directory as starting point for the relative path. This patch fixes this. Is there another way NAR.py should be used that I'm missing? I wasn't able to find any file importing NAR.py outside of misc/Python.