### PR TITLE
support for output var assignment in op execution

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ Str=`ls src/*.c src/NetworkNAR/*.c | xargs`
 echo $Str
 echo "Compilation started:"
 BaseFlags="-g -pthread -lpthread -D_POSIX_C_SOURCE=199506L -pedantic -std=c99 -g3 -O3 $Str -lm -oNAR"
-NoWarn="-Wno-tautological-compare -Wno-dollar-in-identifier-extension -Wno-unused-parameter -Wno-unused-variable"
+NoWarn="-Wno-unknown-pragmas -Wno-tautological-compare -Wno-dollar-in-identifier-extension -Wno-unused-parameter -Wno-unused-variable"
 gcc $@ -DSTAGE=1 -Wall -Wextra -Wformat-security $NoWarn $BaseFlags
 echo "First stage done, generating RuleTable.c now, and finishing compilation."
 ./NAR NAL_GenerateRuleTable > ./src/RuleTable.c

--- a/evaluation.py
+++ b/evaluation.py
@@ -170,7 +170,7 @@ print("Correctly answered ones = " + str(QuestionsAnsweredGlobal))
 print("Answer ratio = " + str(QuestionsAnsweredGlobal / QuestionsTotalGlobal))
 
 print("\nSheep counting task:")
-print(subprocess.getoutput("python3 ./misc/Python/count_sheep.py").split("\n")[-1])
+print(subprocess.getoutput("cd ./misc/Python/ && python3 count_sheep.py").split("\n")[-1])
 
 #Print procedure learning metrics:
 print("\nNow running procedure learning examples for 10K iterations each:")

--- a/libbuild.sh
+++ b/libbuild.sh
@@ -17,7 +17,7 @@ Str=`ls src/*.c src/NetworkNAR/*.c | xargs`
 
 echo "Compilation started:"
 BaseFlags="-D_POSIX_C_SOURCE=199506L -pedantic -std=c99 -pthread -lpthread -lm"
-NoWarn="-Wno-tautological-compare -Wno-dollar-in-identifier-extension -Wno-unused-parameter -Wno-unused-variable"
+NoWarn="-Wno-unknown-pragmas -Wno-tautological-compare -Wno-dollar-in-identifier-extension -Wno-unused-parameter -Wno-unused-variable"
 gcc -mfpmath=sse -msse2 -DSTAGE=1 -Wall -Wextra -Wformat-security $Str $NoWarn $BaseFlags -oNAR_first_stage || gcc -DSTAGE=1 -Wall -Wextra -Wformat-security $Str $NoWarn $BaseFlags -oNAR_first_stage
 echo "First stage done, generating RuleTable.c now, and finishing compilation."
 

--- a/misc/C/main.c
+++ b/misc/C/main.c
@@ -1,12 +1,14 @@
+//build with: gcc -lONA -lm main.c
 #include <stdio.h>
 #include "./../../src/NAR.h"
 //#include <ona/NAR.h>
 
 bool executed = false;
-void NAR_Op()
+Substitution NAR_Op()
 {
     puts("Hello world");
     executed=true;
+    return (Substitution) {0};
 }
 int main()
 {

--- a/misc/C/main_variableOp.c
+++ b/misc/C/main_variableOp.c
@@ -1,0 +1,35 @@
+//build with: gcc -lONA -lm main_variableOp.c
+#include <stdio.h>
+#include "./../../src/NAR.h"
+//#include <ona/NAR.h>
+
+bool executed = false; //arg = ({SELF} * (input * output)) 
+Feedback NAR_Op(Term arg) // 1 2  3   4     5  6      7
+{                         // * {} *   SELF     input  output
+    puts("Hello world");
+    executed=true;
+    Feedback feedback = {0};
+    Atom variable = arg.atoms[7-1];
+    Term result = Narsese_AtomicTerm("42");
+    if(Variable_isVariable(variable))
+    {
+        feedback.subs.map[(int) variable] = result;
+    }
+    else
+    if(variable != result.atoms[0]) //if the var already is a specific value, then the value has to match
+    {
+        feedback.failed = true;
+    }
+    return feedback;
+}
+
+int main()
+{
+    NAR_INIT();
+    NAR_AddOperation("^op", NAR_Op);
+    NAR_AddInputNarsese("<((a &/ <({SELF} * (2 * #1)) --> ^op>) &/ <({SELF} * (#1 * $2)) --> ^op>) =/> <$2 --> result>>.");
+    NAR_AddInputNarsese("a. :|:");
+    NAR_AddInputNarsese("<42 --> result>! :|:");
+    Globals_assert(executed, "Eecution should have happened!");
+    return 0;
+}

--- a/misc/CPP/main.cpp
+++ b/misc/CPP/main.cpp
@@ -1,3 +1,4 @@
+//build with: g++ -lONA -lm main.cpp
 #include <iostream>
 //namespace ona { //if used with other namespaces
 extern "C" {
@@ -9,14 +10,16 @@ extern "C" {
 //using namespace ona;
 
 bool executed = false;
-void NAR_Op()
+Feedback NAR_Op()
 {
     std::cout << "Hello world" << std::endl;
     executed=true;
+    return (Feedback) {0};
 }
 int main()
 {
     NAR_INIT();
+    MOTOR_BABBLING_CHANCE = 0.0;
     NAR_AddOperation((char*) "^op", (Action) NAR_Op);
     NAR_AddInputNarsese((char*) "<(a &/ ^op) =/> g>.");
     NAR_AddInputNarsese((char*) "a. :|:");

--- a/misc/Python/NAR_numerics2.py
+++ b/misc/Python/NAR_numerics2.py
@@ -1,0 +1,76 @@
+"""
+ * The MIT License
+ *
+ * Copyright 2022 The OpenNARS authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * """
+
+import NAR
+
+ops1 = { "^inc":     lambda x: x+1 ,
+         "^dec":     lambda x: x-1 }
+
+ops2 = { "^add":     lambda x, y: x+y  ,
+         "^sub":     lambda x, y: x-y  ,
+         "^mul":     lambda x, y: x*y  ,
+         "^div":     lambda x, y: x/y  ,
+         "^greater": lambda x, y: x>y  ,
+         "^equal":   lambda x, y: x==y ,
+         "^smaller": lambda x, y: x<y  }
+
+for i, (name, f) in enumerate(ops1.items()):
+    NAR.AddInput("*setopname %d %s" % (i+1, name))
+for i, (name, f) in enumerate(ops2.items()):
+    NAR.AddInput("*setopname %d %s" % (i+1, name))
+
+def NAR_numerics_execute(executions, requestOutputArgs):
+    if len(executions) > 0:
+        result = 0.0
+        for i, execution in enumerate(executions):
+            opname = execution["operator"]
+            if opname in ops2.keys() and len(execution["arguments"]) > 0:
+                try:
+                    if " *" in execution["arguments"]:
+                        x, y, _ = execution["arguments"].replace("(","").replace(")","").split(" * ")
+                        result = ops2[opname](float(x), float(y))
+                        if requestOutputArgs:
+                            ret = NAR.AddInput("((%s * %s) * %s)" % (x, y, result))
+                            NAR_numerics_execute(ret["executions"], ret["requestOutputArgs"])
+                except:
+                    None #wrong args, no result
+            if opname in ops1.keys() and len(execution["arguments"]) > 0:
+                try:
+                    if " *" in execution["arguments"]:
+                        x, _ = execution["arguments"].replace("(","").replace(")","").split(" * ")
+                        result = ops1[opname](float(x))
+                        if requestOutputArgs:
+                            ret = NAR.AddInput("(%s * %s)" % (x, result))
+                            NAR_numerics_execute(ret["executions"], ret["requestOutputArgs"])
+                except:
+                    None #wrong args, no result
+
+if __name__ == "__main__":
+    while True:
+        try:
+            inp = input().rstrip("\n")
+        except:
+            exit(0)
+        ret = NAR.AddInput(inp)
+        NAR_numerics_execute(ret["executions"], ret["requestOutputArgs"])

--- a/misc/Python/numerics2_ex1.nal
+++ b/misc/Python/numerics2_ex1.nal
@@ -1,0 +1,10 @@
+*volume=0
+*setopname 1 ^inc
+*setopstdin 1
+*setopname 2 ^say
+*motorbabbling=false
+
+<((<#1 --> value> &/ <({SELF} * (#1 * #result)) --> ^inc>) &/ <({SELF} * #result) --> ^say>) =/> G>.
+
+<5 --> value>. :|:
+G! :|:

--- a/misc/ROS/ona-ros/src/ona.cpp
+++ b/misc/ROS/ona-ros/src/ona.cpp
@@ -47,44 +47,54 @@ void narseseInputCallback(const std_msgs::String::ConstPtr& msg){
     NAR_AddInputNarsese((char*) msg->data.c_str());
 }
 
-static void ROSNAR_op1(Term args){
+static Feedback ROSNAR_op1(Term args){
     publish("^op1", args);
+    return (Feedback) {0};
 }
 
-static void ROSNAR_op2(Term args){
+static Feedback ROSNAR_op2(Term args){
     publish("^op2", args);
+    return (Feedback) {0};
 }
 
-static void ROSNAR_op3(Term args){
+static Feedback ROSNAR_op3(Term args){
     publish("^op3", args);
+    return (Feedback) {0};
 }
 
-static void ROSNAR_op4(Term args){
+static Feedback ROSNAR_op4(Term args){
     publish("^op4", args);
+    return (Feedback) {0};
 }
 
-static void ROSNAR_op5(Term args){
+static Feedback ROSNAR_op5(Term args){
     publish("^op5", args);
+    return (Feedback) {0};
 }
 
-static void ROSNAR_op6(Term args){
+static Feedback ROSNAR_op6(Term args){
     publish("^op6", args);
+    return (Feedback) {0};
 }
 
-static void ROSNAR_op7(Term args){
+static Feedback ROSNAR_op7(Term args){
     publish("^op7", args);
+    return (Feedback) {0};
 }
 
-static void ROSNAR_op8(Term args){
+static Feedback ROSNAR_op8(Term args){
     publish("^op8", args);
+    return (Feedback) {0};
 }
 
-static void ROSNAR_op9(Term args){
+static Feedback ROSNAR_op9(Term args){
     publish("^op9", args);
+    return (Feedback) {0};
 }
 
-static void ROSNAR_op10(Term args){
+static Feedback ROSNAR_op10(Term args){
     publish("^op10", args);
+    return (Feedback) {0};
 }
 
 void ROSNAR_INIT(){

--- a/misc/ROS/ona-ros/src/ona.hpp
+++ b/misc/ROS/ona-ros/src/ona.hpp
@@ -44,15 +44,15 @@ void publish(const char* name, Term args);
 
 void narseseInputCallback(const std_msgs::String::ConstPtr& msg);
 
-static void ROSNAR_op_left(Term args);
-static void ROSNAR_op_right(Term args);
-static void ROSNAR_op_up(Term args);
-static void ROSNAR_op_down(Term args);
-static void ROSNAR_op_say(Term args);
-static void ROSNAR_op_pick(Term args);
-static void ROSNAR_op_drop(Term args);
-static void ROSNAR_op_go(Term args);
-static void ROSNAR_op_activate(Term args);
-static void ROSNAR_op_deactivate(Term args);
+static Feedback ROSNAR_op_left(Term args);
+static Feedback ROSNAR_op_right(Term args);
+static Feedback ROSNAR_op_up(Term args);
+static Feedback ROSNAR_op_down(Term args);
+static Feedback ROSNAR_op_say(Term args);
+static Feedback ROSNAR_op_pick(Term args);
+static Feedback ROSNAR_op_drop(Term args);
+static Feedback ROSNAR_op_go(Term args);
+static Feedback ROSNAR_op_activate(Term args);
+static Feedback ROSNAR_op_deactivate(Term args);
 
 #endif

--- a/src/Decision.c
+++ b/src/Decision.c
@@ -89,6 +89,31 @@ void Decision_Execute(Decision *decision)
             return;
         }
         feedback.subs.success = true; //the value assignment didn't came from substitution but from the op execution so we simply set it to true
+        if(decision->op[i].stdinOutput)
+        {
+            puts("//Operation result product expected: ");
+            fflush(stdout);
+            //Synch 0 input from Python interface
+            char line0[10] = {0};
+            if(fgets(line0, 10, stdin) == NULL)
+            {
+                return;
+            }
+            assert(line0[0] == '0' && line0[1] == '\n', "Synch 0 not sent");
+            //Now the actual argument product:
+            char line[1024] = {0};
+            if(fgets(line, 1024, stdin) == NULL)
+            {
+                return;
+            }
+            Term specific_args = Narsese_Term(line);
+            Term argpart = Term_ExtractSubterm(&decision->arguments[i], 2);
+            feedback.subs = Variable_Unify(&argpart, &specific_args);
+            if(!feedback.subs.success)
+            {
+                return;
+            }
+        }
         for(int j=0; j<i; j++) //also apply the substitution to all following operations in the compound op
         {
             bool success;

--- a/src/Decision.c
+++ b/src/Decision.c
@@ -70,8 +70,8 @@ void Decision_Execute(Decision *decision)
     {
         assert(decision->operationID[i], "Error");
         decision->op[i] = operations[decision->operationID[i]-1];
-        Term feedback = decision->op[i].term; //atomic operation / operator
-        //and add operator feedback
+        Term feedbackTerm = decision->op[i].term; //atomic operation / operator
+        //and add operator feedback event
         if(decision->arguments[i].atoms[0] > 0) //operation with args
         {
             Term operation = {0};
@@ -80,20 +80,43 @@ void Decision_Execute(Decision *decision)
             {
                 return;
             }
-            feedback = operation;
+            feedbackTerm = operation;
         }
         Narsese_PrintTerm(&decision->op[i].term); fputs(" executed with args ", stdout); Narsese_PrintTerm(&decision->arguments[i]); puts(""); fflush(stdout);
-        (*decision->op[i].action)(decision->arguments[i]);
-        NAR_AddInputBelief(feedback);
-        //assumption of failure extension to specific cases not experienced before:
-        if(ANTICIPATE_FOR_NOT_EXISTING_SPECIFIC_TEMPORAL_IMPLICATION && decision->missing_specific_implication.term.atoms[0])
+        Feedback feedback = (*decision->op[i].action)(decision->arguments[i]);
+        if(feedback.failed) //TODO improve (leaves option for operation to fail, but we don't want each op having to set it to true...)
         {
-            Term postcondition = Term_ExtractSubterm(&decision->missing_specific_implication.term, 2);
-            Concept *postc = Memory_Conceptualize(&postcondition, currentTime, false);
-            if(postc != NULL)
+            return;
+        }
+        feedback.subs.success = true; //the value assignment didn't came from substitution but from the op execution so we simply set it to true
+        for(int j=0; j<i; j++) //also apply the substitution to all following operations in the compound op
+        {
+            bool success;
+            decision->arguments[j] = Variable_ApplySubstitute(decision->arguments[j], feedback.subs, &success);
+            if(!success)
             {
-                Decision_AddNegativeConfirmation(decision->reason, decision->missing_specific_implication, decision->operationID[i], postc);
+                return;
             }
+        }
+        bool success;
+        feedbackTerm = Variable_ApplySubstitute(feedbackTerm, feedback.subs, &success);
+        if(success)
+        {
+            NAR_AddInputBelief(feedbackTerm);
+            //assumption of failure extension to specific cases not experienced before:
+            if(ANTICIPATE_FOR_NOT_EXISTING_SPECIFIC_TEMPORAL_IMPLICATION && decision->missing_specific_implication.term.atoms[0])
+            {
+                Term postcondition = Term_ExtractSubterm(&decision->missing_specific_implication.term, 2);
+                Concept *postc = Memory_Conceptualize(&postcondition, currentTime, false);
+                if(postc != NULL)
+                {
+                    Decision_AddNegativeConfirmation(decision->reason, decision->missing_specific_implication, decision->operationID[i], postc);
+                }
+            }
+        }
+        else
+        {
+            return;
         }
     }
 }
@@ -203,6 +226,7 @@ Decision Decision_BestCandidate(Concept *goalconcept, Event *goal, long currentT
     Decision decision = {0};
     Implication bestImp = {0};
     long bestComplexity = COMPOUND_TERM_SIZE_MAX+1;
+    bool genericGoalgenericConcept = Variable_hasVariable(&goalconcept->term, true, true, true) && Variable_hasVariable(&goal->term, true, true, true);
     Substitution subs = Variable_Unify(&goalconcept->term, &goal->term);
     if(subs.success)
     {
@@ -235,7 +259,7 @@ Decision Decision_BestCandidate(Concept *goalconcept, Event *goal, long currentT
                                 Implication specific_imp = imp; //can only be completely specific
                                 bool success;
                                 specific_imp.term = Variable_ApplySubstitute(specific_imp.term, subs2, &success);
-                                if(success && !Variable_hasVariable(&specific_imp.term, true, true, true))
+                                if(success && (!genericGoalgenericConcept || !Variable_hasVariable(&specific_imp.term, true, true, true)))
                                 {
                                     specific_imp.sourceConcept = cmatch;
                                     specific_imp.sourceConceptId = cmatch->id;

--- a/src/Memory.h
+++ b/src/Memory.h
@@ -61,6 +61,7 @@ typedef struct
     Term term;
     Action action;
     Term arguments[OPERATIONS_BABBLE_ARGS_MAX];
+    bool stdinOutput;
 }Operation;
 extern bool ontology_handling;
 extern Event selectedBeliefs[BELIEF_EVENT_SELECTIONS]; //better to be global

--- a/src/Memory.h
+++ b/src/Memory.h
@@ -50,7 +50,12 @@ extern double conceptPriorityThreshold;
 
 //Data structure//
 //--------------//
-typedef void (*Action)(Term);
+typedef struct
+{
+    Substitution subs;
+    bool failed;
+}Feedback; //operation feedback
+typedef Feedback (*Action)(Term);
 typedef struct
 {
     Term term;

--- a/src/NAR.h
+++ b/src/NAR.h
@@ -42,7 +42,7 @@ extern long currentTime;
 
 //Callback function types//
 //-----------------------//
-//typedef void (*Action)(Term);     //already defined in Memory
+//typedef Feedback (*Action)(Term);     //already defined in Memory
 
 //Methods//
 //-------//

--- a/src/Narsese.c
+++ b/src/Narsese.c
@@ -731,7 +731,7 @@ Term Narsese_getOperationTerm(Term *term)
         }
         return potential_op_seq;
     }
-    if(Narsese_isOperation(term)) //operator
+    if(Narsese_isOperation(term)) //operation
     {
         return *term;
     }
@@ -774,11 +774,11 @@ bool Narsese_HasSimpleAtom(Term *term)
 
 bool Narsese_HasOperation(Term *term)
 {
-    if(Narsese_getOperationAtom(term)) //don't conceptualize operations
+    if(Narsese_getOperationAtom(term))
     {
         return true;
     }
-    if(Narsese_copulaEquals(term->atoms[0], SEQUENCE)) //or any seq with an op for that matter
+    if(Narsese_copulaEquals(term->atoms[0], SEQUENCE))
     {
         for(int i=0; i<COMPOUND_TERM_SIZE_MAX; i++)
         {

--- a/src/Shell.c
+++ b/src/Shell.c
@@ -24,8 +24,9 @@
 
 #include "Shell.h"
 
-static void Shell_op_nop(Term args)
+static Feedback Shell_op_nop(Term args)
 {
+    return (Feedback) {0};
 }
 void Shell_NARInit()
 {

--- a/src/Shell.c
+++ b/src/Shell.c
@@ -264,6 +264,14 @@ int Shell_ProcessInput(char *line)
             operations[opID - 1].arguments[opArgID-1] = Narsese_Term(argname);
         }
         else
+        if(!strncmp("*setopstdin ", line, strlen("*setopstdin ")))
+        {
+            int opID;
+            char opname[ATOMIC_TERM_LEN_MAX] = {0};
+            sscanf(&line[strlen("*setopstdin ")], "%d", &opID);
+            operations[opID - 1].stdinOutput = true;
+        }
+        else
         if(strspn(line, "0123456789") && strlen(line) == strspn(line, "0123456789"))
         {
             unsigned int steps;

--- a/src/system_tests/Alien_Test.h
+++ b/src/system_tests/Alien_Test.h
@@ -23,22 +23,25 @@
  */
 
 bool NAR_Alien_Left_executed = false;
-void NAR_Alien_Left()
+Feedback NAR_Alien_Left()
 {
     puts("NAR invoked left");
     NAR_Alien_Left_executed = true;
+    return (Feedback) {0};
 }
 bool NAR_Alien_Right_executed = false;
-void NAR_Alien_Right()
+Feedback NAR_Alien_Right()
 {
     puts("NAR invoked right");
     NAR_Alien_Right_executed = true;
+    return (Feedback) {0};
 }
 bool NAR_Alien_Shoot_executed = false;
-void NAR_Alien_Shoot()
+Feedback NAR_Alien_Shoot()
 {
     puts("NAR invoked shoot");
     NAR_Alien_Shoot_executed = true;
+    return (Feedback) {0};
 }
 void NAR_Alien(long iterations)
 {

--- a/src/system_tests/Cartpole_Test.h
+++ b/src/system_tests/Cartpole_Test.h
@@ -3,7 +3,7 @@ static double angle = -3.1415/2.0;
 static double angle_velocity = 0.0;
 static double position = 0.0;
 static double max_angle_velocity = 0.3;
-static void NAR_CP_Left()
+static Feedback NAR_CP_Left()
 {
     double reverse = angle > 0 ? 1 : -1;
     //if(position > 0.0 && position < 1.0)
@@ -11,8 +11,9 @@ static void NAR_CP_Left()
         angle_velocity -= reverse * 0.3;
     }
     velocity -= 0.1;
+    return (Feedback) {0};
 }
-static void NAR_CP_Right()
+static Feedback NAR_CP_Right()
 {
     double reverse = angle > 0 ? 1 : -1;
     //if(position > 0.0 && position < 1.0)
@@ -20,6 +21,7 @@ static void NAR_CP_Right()
         angle_velocity += reverse * 0.3;
     }
     velocity += 0.1;
+    return (Feedback) {0};
 }
 static double successes = 0;
 static double failures = 0;

--- a/src/system_tests/Follow_Test.h
+++ b/src/system_tests/Follow_Test.h
@@ -23,16 +23,18 @@
  */
 
 bool NAR_Follow_Test_Left_executed = false;
-void NAR_Follow_Test_Left()
+Feedback NAR_Follow_Test_Left()
 {
     puts("left executed by NAR");
     NAR_Follow_Test_Left_executed = true;
+    return (Feedback) {0};
 }
 bool NAR_Follow_Test_Right_executed = false;
-void NAR_Follow_Test_Right()
+Feedback NAR_Follow_Test_Right()
 {
     puts("right executed by NAR");
     NAR_Follow_Test_Right_executed = true;
+    return (Feedback) {0};
 }
 void NAR_Follow_Test()
 {

--- a/src/system_tests/Multistep_Test.h
+++ b/src/system_tests/Multistep_Test.h
@@ -23,16 +23,18 @@
  */
 
 bool NAR_Lightswitch_GotoSwitch_executed = false;
-void NAR_Lightswitch_GotoSwitch()
+Feedback NAR_Lightswitch_GotoSwitch()
 {
     NAR_Lightswitch_GotoSwitch_executed = true;
     puts("NAR invoked goto switch");
+    return (Feedback) {0};
 }
 bool NAR_Lightswitch_ActivateSwitch_executed = false;
-void NAR_Lightswitch_ActivateSwitch()
+Feedback NAR_Lightswitch_ActivateSwitch()
 {
     NAR_Lightswitch_ActivateSwitch_executed = true;
     puts("NAR invoked activate switch");
+    return (Feedback) {0};
 }
 void NAR_Multistep_Test()
 {

--- a/src/system_tests/Pong2_Test.h
+++ b/src/system_tests/Pong2_Test.h
@@ -23,19 +23,22 @@
  */
 
 bool NAR_Pong_Left_executed = false;
-void NAR_Pong_Left()
+Feedback NAR_Pong_Left()
 {
     NAR_Pong_Left_executed = true;
+    return (Feedback) {0};
 }
 bool NAR_Pong_Right_executed = false;
-void NAR_Pong_Right()
+Feedback NAR_Pong_Right()
 {
     NAR_Pong_Right_executed = true;
+    return (Feedback) {0};
 }
 bool NAR_Pong_Stop_executed = false;
-void NAR_Pong_Stop()
+Feedback NAR_Pong_Stop()
 {
     NAR_Pong_Stop_executed = true;
+    return (Feedback) {0};
 }
 void NAR_Pong2(long iterations)
 {

--- a/src/system_tests/Procedure_Test.h
+++ b/src/system_tests/Procedure_Test.h
@@ -23,10 +23,11 @@
  */
 
 bool NAR_Procedure_Test_Op_executed = false;
-void NAR_Procedure_Test_Op()
+Feedback NAR_Procedure_Test_Op()
 {
     puts("op executed by NAR");
     NAR_Procedure_Test_Op_executed = true;
+    return (Feedback) {0};
 }
 void NAR_Procedure_Test()
 {

--- a/src/system_tests/Robot_Test.h
+++ b/src/system_tests/Robot_Test.h
@@ -37,10 +37,10 @@ char direction = DIRECTION_RIGHT; //right, right down, down, left down, left, le
 bool allowAction = false;
 
 //Angle transition via ^left operator
-void NAR_Robot_Left()
+Feedback NAR_Robot_Left()
 {
     if(!allowAction)
-        return;
+        return (Feedback) {0};
     if(direction == DIRECTION_RIGHT)
         direction = DIRECTION_RIGHT_UP;
     else
@@ -65,13 +65,14 @@ void NAR_Robot_Left()
     if(direction == DIRECTION_RIGHT_DOWN)
         direction = DIRECTION_RIGHT;
     allowAction = false;
+    return (Feedback) {0};
 }
 
 //Angle transition via ^right operator
-void NAR_Robot_Right()
+Feedback NAR_Robot_Right()
 {
     if(!allowAction)
-        return;
+        return (Feedback) {0};
     if(direction == DIRECTION_RIGHT)
         direction = DIRECTION_RIGHT_DOWN;
     else
@@ -96,6 +97,7 @@ void NAR_Robot_Right()
     if(direction == DIRECTION_RIGHT_UP)
         direction = DIRECTION_RIGHT;
     allowAction = false;
+    return (Feedback) {0};
 }
 
 //The world is composed of worldsizeX * worldsizeY cells
@@ -411,10 +413,10 @@ int eaten = 0;
 int moves = 0;
 
 //Forward move
-void NAR_Robot_Forward()
+Feedback NAR_Robot_Forward()
 {
     if(!allowAction)
-        return;
+        return (Feedback) {0};
     Perception percept = Agent_View();
     //progress movement
     if(pX != percept.forward_pX || pY != percept.forward_pY)
@@ -424,6 +426,7 @@ void NAR_Robot_Forward()
     pX = percept.forward_pX;
     pY = percept.forward_pY;
     allowAction = false;
+    return (Feedback) {0};
 }
 
 void buildRooms()

--- a/src/system_tests/Sequence_Test.h
+++ b/src/system_tests/Sequence_Test.h
@@ -23,19 +23,22 @@
  */
 
 bool op_1_executed = false;
-void op_1()
+Feedback op_1()
 {
     op_1_executed = true;
+    return (Feedback) {0};
 }
 bool op_2_executed = false;
-void op_2()
+Feedback op_2()
 {
     op_2_executed = true;
+    return (Feedback) {0};
 }
 bool op_3_executed = false;
-void op_3()
+Feedback op_3()
 {
     op_3_executed = true;
+    return (Feedback) {0};
 }
 void NAR_Sequence_Test()
 {

--- a/src/system_tests/Testchamber_Test.h
+++ b/src/system_tests/Testchamber_Test.h
@@ -30,45 +30,53 @@ static bool goto_l0 = false;
 static bool goto_l1 = false;
 static bool activate = false;
 static bool deactivate = false;
-void NAR_TestChamber_goto_s0()
+Feedback NAR_TestChamber_goto_s0()
 {
     goto_s0 = true;
     puts("NAR goto s0");
+    return (Feedback) {0};
 }
-void NAR_TestChamber_goto_s1()
+Feedback NAR_TestChamber_goto_s1()
 {
     goto_s1 = true;
     puts("NAR goto s1");
+    return (Feedback) {0};
 }
-void NAR_TestChamber_goto_s2()
+Feedback NAR_TestChamber_goto_s2()
 {
     goto_s2 = true;
     puts("NAR goto s2");
+    return (Feedback) {0};
 }
-void NAR_TestChamber_goto_s3()
+Feedback NAR_TestChamber_goto_s3()
 {
     goto_s3 = true;
     puts("NAR goto s3");
+    return (Feedback) {0};
 }
-void NAR_TestChamber_goto_l0()
+Feedback NAR_TestChamber_goto_l0()
 {
     goto_l0 = true;
     puts("NAR goto l0");
+    return (Feedback) {0};
 }
-void NAR_TestChamber_goto_l1()
+Feedback NAR_TestChamber_goto_l1()
 {
     goto_l1 = true;
     puts("NAR goto l1");
+    return (Feedback) {0};
 }
-void NAR_TestChamber_activate()
+Feedback NAR_TestChamber_activate()
 {
     activate = true;
     puts("NAR activate");
+    return (Feedback) {0};
 }
-void NAR_TestChamber_deactivate()
+Feedback NAR_TestChamber_deactivate()
 {
     deactivate = true;
     puts("NAR deactivate");
+    return (Feedback) {0};
 }
 void NAR_TestChamber()
 {

--- a/src/system_tests/UDPNAR_Test.h
+++ b/src/system_tests/UDPNAR_Test.h
@@ -25,9 +25,10 @@
 #include "./../NetworkNAR/UDPNAR.h"
 
 bool NAR_UDPNAR_Test_op_left_executed = false;
-void NAR_UDPNAR_Test_op_left()
+Feedback NAR_UDPNAR_Test_op_left()
 {
     NAR_UDPNAR_Test_op_left_executed = true;
+    return (Feedback) {0};
 }
 
 void NAR_UDPNAR_Test()


### PR DESCRIPTION
TODO: find solution for python API. By something like
*outputstdin op_id
whereby when say
<({SELF} * ((1 * 2) * #1)) --> ^add>
is executed "^add executed with args ((1 * 2) * #1))"
it then makes a stdin request to obtain
((1 * 2) * 3))
then parsing it, and obatining the substitution map {#1 -> #3) from there.
With this feature the idea will also work without touching C code when used from Python.
Also adapt NAR_numerics.py accordingly.
