### PR TITLE
auto-unnegate negated tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ NAR.dll
 src/RuleTable.c
 .envrc
 NAR.dSYM/
+.idea/

--- a/src/Event.c
+++ b/src/Event.c
@@ -23,10 +23,21 @@
  */
 
 #include "Event.h"
+#include "Narsese.h"
 
 long base = 1;
 Event Event_InputEvent(Term term, char type, Truth truth, double occurrenceTimeOffset, long currentTime)
 {
+	
+	bool AUTO_UNNEGATE_TASKS = true; //TODO move to config
+	if (AUTO_UNNEGATE_TASKS) {
+		if (Narsese_copulaEquals(&term, NEGATION)) {
+			term = Term_ExtractSubterm(&term, 0);
+			//truth = truth.negate();
+			truth = (Truth) { .frequency = 1-truth.frequency, .confidence = truth.confidence };
+		}
+	}
+
     return (Event) { .term = term,
                      .type = type, 
                      .truth = truth, 


### PR DESCRIPTION
A simple normalization step for negated input tasks that un-negates the term and inverts the truth frequency.  

**this should be functionally equivalent to the Truth_Negation rule - but without needing to create any separate concepts, ex: X vs. !X.**

I was unable to test the effect of this code because I could find no example that actually seems to make use of negation, or for that matter, any belief or goal with a frequency other than 1.0.  assistance would be appreciated here.  maybe this step is already being applied somewhere but i doubt it - having grepped through code occurrences of NEGATION i can not find it.

the lack of this normalization can been seen as a "combinatorial memory leak" in NARS implementations like ONA.  while NAL clearly follows fuzzy logic t-norm formulas which generally preserve "de morgan's law" in negations, **there ought not to be separate concepts where the semantics are meant to be equivalent**.  this will produce a redundant explosive subset of negated 'shadow' concepts that could otherwise be collapsed, beliefs and goals included, into their unnegated core term.

there are other semantic symmetries like this that i could illustrate, but this is probably the most widely applicable and far-reaching.  assuming negation is applied anywhere at all.


the performance effects of applying this normalization ought to be noticeable, towards better or worse.  maybe the shadow negation concepts, if they are meant to exist, provide some benefit, but it will not be without memory cost.  so i included a variable to be assigned by a configuration option to toggle it for comparison.