### PR TITLE
Ignore files generated and used by Clangd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ NAR.dll
 src/RuleTable.c
 .envrc
 NAR.dSYM/
+
+# For Clangd
+.cache/
+compile_commands.json


### PR DESCRIPTION
This is just a minute PR so that files generated (and used) by Clangd don’t make a mess in the repository (which is especially annoying when switching between branches).