### PR TITLE
Old-fashioned (OpenNARS) idea: prediction evidence to contribute to observed

### DIFF
--- a/examples/nal/prediction.nal
+++ b/examples/nal/prediction.nal
@@ -1,0 +1,7 @@
+*motorbabbling=false
+*volume=0
+<(b &/ ^left) =/> G>.
+<a =/> b>.
+a. :|:
+G! :|:
+//expected: ^left executed with args

--- a/src/Config.h
+++ b/src/Config.h
@@ -145,9 +145,11 @@
 //Maximum value for confidence
 #define MAX_CONFIDENCE 0.99
 //Prediction reliance (how much to trust own predictions at most in terms of confidence)
-#define PREDICTION_RELIANCE 0.01
+#define PREDICTION_RELIANCE 0.005
 //How confident a prediction needs to be to contribute to observed evidence
 #define PREDICTION_CONFIDENCE_MIN 0.3
+//Max observation confidence to be combined with predicted evidence
+#define OBSERVATION_CONFIDENCE_MAX MIN_CONFIDENCE
 
 /*-----------------------*/
 /* Derivation parameters */

--- a/src/Config.h
+++ b/src/Config.h
@@ -144,6 +144,10 @@
 #define TRUTH_PROJECTION_DECAY_INITIAL 0.8
 //Maximum value for confidence
 #define MAX_CONFIDENCE 0.99
+//Prediction reliance (how much to trust own predictions at most in terms of confidence)
+#define PREDICTION_RELIANCE 0.01
+//How confident a prediction needs to be to contribute to observed evidence
+#define PREDICTION_CONFIDENCE_MIN 0.3
 
 /*-----------------------*/
 /* Derivation parameters */

--- a/src/Decision.c
+++ b/src/Decision.c
@@ -461,6 +461,18 @@ void Decision_Anticipate(int operationID, Term opTerm, long currentTime)
                                 {
                                     c->usage = Usage_use(c->usage, currentTime, false);
                                     c->predicted_belief = result;
+                                    //revise with existing belief:
+                                    if(PREDICTION_RELIANCE > 0.0)
+                                    {
+                                        Event prediction = Inference_EventUpdate(&c->predicted_belief, currentTime);
+                                        if(prediction.truth.confidence > PREDICTION_CONFIDENCE_MIN)
+                                        {
+                                            prediction.truth.confidence *= PREDICTION_RELIANCE;
+                                            Stamp temp = c->belief_spike.stamp;
+                                            c->belief_spike = Inference_RevisionAndChoice(&c->belief_spike, &prediction, currentTime, NULL);
+                                            c->belief_spike.stamp = temp; //don't include prediction evidence in stamp, it's only a minor contribution anyway and Stamp size is limited
+                                        }
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Allow predicted evidence to contribute to observed evidence similar as originally envisioned but with a configurable parameter which balances observation and prediction similar as in Kalman filters.

**This will likely not be merged until clear uses emerge.**
A question which underlies this: in which cases do percepts need to be "made-up"? Isn't building stable temporal implications which allow for various ways of subgoaling (ending at realized goals corresponding to from current observations derivable evidence) even when particular percepts are absent sufficient (or even the way to go) to handle this? How is the system supposed to take into account properly the case where some predicted percepts are absent when it just proceeds as-predicted (hypothesis failure versus sensor unreliability)? Even if a tradeoff is possible, sensors should be quite trustable.