### PR TITLE
Fix some word typos

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -185,6 +185,6 @@
 //Filtering sub-statement terms with variables and atoms both like (&, $1, a)
 #define TERMS_WITH_VARS_AND_ATOMS_FILTER true
 //Use functional equivalence
-#define FUNCTIONAL_EQUIVALENCE true
+#define FUNCTIONAL_EQUIVALENCE false
 
 #endif

--- a/src/Config.h
+++ b/src/Config.h
@@ -86,7 +86,7 @@
 #define UNIFICATION_DEPTH 31
 //If var intro should be allowed at all (includes sensorimotor!)
 #define ALLOW_VAR_INTRO true
-//Numeric term similarity distance scale (everything beyound distance leads to conf 0 analogy!)
+//Numeric term similarity distance scale (everything beyond distance leads to conf 0 analogy!)
 #define SIMILARITY_DISTANCE 1.0
 
 /*---------------------------------*/
@@ -120,7 +120,7 @@
 #define OPERATIONS_MAX 10
 //Maximum amount of arguments an operation can babble
 #define OPERATIONS_BABBLE_ARGS_MAX 10
-//Maximum size of the stamp in terms of evidental base id's
+//Maximum size of the stamp in terms of evidential base id's
 #define STAMP_SIZE 10
 //Maximum Implication table size
 #define TABLE_SIZE 20
@@ -152,8 +152,8 @@
 #define NAR_DEFAULT_CONFIDENCE 0.9
 //Default confidence for analytical premise
 #define RELIANCE 0.9
-//NAL evidental horizon
-#define TRUTH_EVIDENTAL_HORIZON_INITIAL 1.0
+//NAL evidential horizon
+#define TRUTH_EVIDENTIAL_HORIZON_INITIAL 1.0
 //Time distance based projection decay of event truth
 #define TRUTH_PROJECTION_DECAY_INITIAL 0.8
 //Maximum value for confidence

--- a/src/Cycle.c
+++ b/src/Cycle.c
@@ -250,7 +250,7 @@ bool Cycle_GoalSequenceDecomposition(Event *selectedGoal, double selectedGoalPri
         {
             bool goalsubs_success;
             componentGoalsTerm[u] = Variable_ApplySubstitute(componentGoalsTerm[u], best_subs, &goalsubs_success);
-            assert(goalsubs_success, "Cycle_GoalSequenceDecomposition: The subsitution succeeded before but not now!");
+            assert(goalsubs_success, "Cycle_GoalSequenceDecomposition: The substitution succeeded before but not now!");
         }
         //build component subgoal according to {(a, b)!, a} |- b! Truth_Deduction
         lastComponentOccurrenceTime = best_c->belief_spike.occurrenceTime;

--- a/src/Cycle.h
+++ b/src/Cycle.h
@@ -45,7 +45,7 @@
 
 //Methods//
 //-------//
-//Apply one operating cyle
+//Apply one operating cycle
 void Cycle_Perform(long currentTime);
 //Init cycle module
 void Cycle_INIT();

--- a/src/Decision.h
+++ b/src/Decision.h
@@ -39,8 +39,8 @@
 //However this isn't checked with individual thresholds
 //as this would be brittle and hard to tune,
 //instead deductive NAL inference is utilized to decide the desire
-//value of each operation goal (for eeach link) individually,
-//whereby the highest-truth expectation option above decison
+//value of each operation goal (for each link) individually,
+//whereby the highest-truth expectation option above decision
 //threshold is chosen.
 //If none however is above decision threshold, the system
 //derived the preconditions of the links as subgoals,

--- a/src/Event.c
+++ b/src/Event.c
@@ -29,8 +29,8 @@ Stamp importstamp = {0};
 
 Event Event_InputEvent(Term term, char type, Truth truth, double occurrenceTimeOffset, long currentTime)
 {
-    Stamp stamp = { .evidentalBase = { base++ } };
-    if(importstamp.evidentalBase[0])
+    Stamp stamp = { .evidentialBase = { base++ } };
+    if(importstamp.evidentialBase[0])
     {
         stamp = importstamp;
         base--; //the stamp ID wasn't used

--- a/src/Inference.c
+++ b/src/Inference.c
@@ -149,7 +149,7 @@ Event Inference_RevisionAndChoice(Event *existing_potential, Event *incoming_spi
         long laterOccurrence = existing_potential->occurrenceTime > incoming_spike->occurrenceTime ? existing_potential->occurrenceTime : incoming_spike->occurrenceTime;
         Event existing_updated = Inference_EventUpdate(existing_potential, laterOccurrence);
         Event incoming_updated = Inference_EventUpdate(incoming_spike, laterOccurrence);
-        //check if there is evidental overlap
+        //check if there is evidential overlap
         bool overlap = Stamp_checkOverlap(&incoming_spike->stamp, &existing_potential->stamp);
         bool isDepVarConj = (Narsese_copulaEquals(incoming_spike->term.atoms[0], CONJUNCTION) || Narsese_copulaEquals(incoming_spike->term.atoms[0], SEQUENCE)) && Variable_hasVariable(&incoming_spike->term, false, true, false);
         //if there is or the terms aren't equal, apply choice, keeping the stronger one:

--- a/src/Inference.h
+++ b/src/Inference.h
@@ -56,7 +56,7 @@ Implication Inference_ImplicationRevision(Implication *a, Implication *b);
 Event Inference_GoalDeduction(Event *component, Implication *compound, long currentTime);
 //{Event (a &/ b)!, Event a.} |- Event b! Truth_Deduction
 Event Inference_GoalSequenceDeduction(Event *compound, Event *component, long currentTime);
-//{Event a!, Event a!} |- Event a! Truth_Revision or Choice (dependent on evidental overlap)
+//{Event a!, Event a!} |- Event a! Truth_Revision or Choice (dependent on evidential overlap)
 Event Inference_RevisionAndChoice(Event *existing_potential, Event *incoming_spike, long currentTime, bool *revised);
 //{Event a., Implication <a =/> b>.} |- Event b.  Truth_Deduction
 Event Inference_BeliefDeduction(Event *component, Implication *compound);

--- a/src/Memory.c
+++ b/src/Memory.c
@@ -38,7 +38,7 @@ Operation operations[OPERATIONS_MAX];
 //Parameters
 bool PRINT_DERIVATIONS = PRINT_DERIVATIONS_INITIAL;
 bool PRINT_INPUT = PRINT_INPUT_INITIAL;
-//Storage arrays for the datastructures
+//Storage arrays for the data structures
 Concept concept_storage[CONCEPTS_MAX];
 Item concept_items_storage[CONCEPTS_MAX];
 Event cycling_belief_event_storage[CYCLING_BELIEF_EVENTS_MAX];
@@ -225,8 +225,8 @@ bool Memory_addCyclingEvent(Event *e, double priority, long currentTime, int lay
     PriorityQueue_Push_Feedback feedback = PriorityQueue_Push(priority_queue, priority);
     if(feedback.added)
     {
-        Event *toRecyle = feedback.addedItem.address;
-        *toRecyle = *e;
+        Event *toRecycle = feedback.addedItem.address;
+        *toRecycle = *e;
         return true;
     }
     return false;

--- a/src/Memory.h
+++ b/src/Memory.h
@@ -84,7 +84,7 @@ extern PriorityQueue cycling_goal_events[CYCLING_GOAL_EVENTS_LAYERS];
 extern HashTable HTconcepts;
 //OccurrenceTimeIndex for accelerating temporal induction
 extern OccurrenceTimeIndex occurrenceTimeIndex;
-//Registered perations
+//Registered operations
 extern Operation operations[OPERATIONS_MAX];
 //Priority threshold for printing derivations
 extern double PRINT_EVENTS_PRIORITY_THRESHOLD;

--- a/src/NAR.c
+++ b/src/NAR.c
@@ -193,7 +193,7 @@ void NAR_AddInputNarsese2(char *narsese_sentence, bool queryCommand, double answ
                     {
                         NAR_PrintAnswer(c->belief_spike.stamp, c->belief_spike.term, c->belief_spike.truth, c->belief_spike.occurrenceTime, c->belief_spike.creationTime);
                     }
-                    if( Truth_Expectation(potential_best_truth) >  Truth_Expectation(best_truth_projected) || //look at occcurrence time in case it's too far away to make a numerical distinction after truth projection:
+                    if( Truth_Expectation(potential_best_truth) >  Truth_Expectation(best_truth_projected) || //look at occurrence time in case it's too far away to make a numerical distinction after truth projection:
                        (Truth_Expectation(potential_best_truth) == Truth_Expectation(best_truth_projected) && c->belief_spike.occurrenceTime > answerOccurrenceTime))
                     {
                         best_stamp = c->belief_spike.stamp;
@@ -212,7 +212,7 @@ void NAR_AddInputNarsese2(char *narsese_sentence, bool queryCommand, double answ
                     {
                         NAR_PrintAnswer(c->predicted_belief.stamp, c->predicted_belief.term, c->predicted_belief.truth, c->predicted_belief.occurrenceTime, c->predicted_belief.creationTime);
                     }
-                    if( Truth_Expectation(potential_best_truth) >  Truth_Expectation(best_truth_projected) || //look at occcurrence time in case it's too far away to make a numerical distinction after truth projection:
+                    if( Truth_Expectation(potential_best_truth) >  Truth_Expectation(best_truth_projected) || //look at occurrence time in case it's too far away to make a numerical distinction after truth projection:
                        (Truth_Expectation(potential_best_truth) == Truth_Expectation(best_truth_projected) && c->predicted_belief.occurrenceTime > answerOccurrenceTime))
                     {
                         best_stamp = c->predicted_belief.stamp;

--- a/src/NAR.h
+++ b/src/NAR.h
@@ -28,7 +28,7 @@
 //////////////////////////////////////
 //  NAR - The main reasoner module  //
 //////////////////////////////////////
-//The API to send events to the reaasoner
+//The API to send events to the reasoner
 //and to register operations it can invoke
 //plus initialization and execution of inference steps
 

--- a/src/Narsese.c
+++ b/src/Narsese.c
@@ -32,7 +32,7 @@ char Narsese_atomMeasurementNames[ATOMS_MAX][ATOMIC_TERM_LEN_MAX];
 //Atomic term names:
 char Narsese_atomNames[ATOMS_MAX][ATOMIC_TERM_LEN_MAX];
 char Narsese_operatorNames[OPERATIONS_MAX][ATOMIC_TERM_LEN_MAX];
-//upper bound of multplier 3 given by [ becoming "(' " replacement
+//upper bound of multiplier 3 given by [ becoming "(' " replacement
 #define REPLACEMENT_LEN 3*NARSESE_LEN_MAX
 //size for the expanded array with spaces for tokenization, has at most 3 times the amount of chars as the replacement array
 #define EXPANSION_LEN REPLACEMENT_LEN*3
@@ -252,7 +252,7 @@ char** Narsese_PrefixTransform(char* narsese_expanded)
     static char* tokens[NARSESE_LEN_MAX+1]; //there cannot be more tokens than chars
     memset(tokens, 0, (NARSESE_LEN_MAX+1)*sizeof(char*)); //and last one stays NULL for sure
     char* token = strtok(narsese_expanded, " ");
-    int nt = 0, nc = NUM_ELEMENTS(Naresese_CanonicalCopulas) - 1;
+    int nt = 0, nc = NUM_ELEMENTS(Narsese_CanonicalCopulas) - 1;
     while(token)
     {
         tokens[nt] = token;
@@ -265,7 +265,7 @@ char** Narsese_PrefixTransform(char* narsese_expanded)
         {
             for(int k=0; k<nc; k++)
             {
-                if(tokens[i+1][0] == (int) Naresese_CanonicalCopulas[k] && tokens[i+1][1] == 0)
+                if(tokens[i+1][0] == (int) Narsese_CanonicalCopulas[k] && tokens[i+1][1] == 0)
                 {
                     goto Continue;
                 }
@@ -695,9 +695,9 @@ void Narsese_INIT()
     Narsese_AtomicTermIndex("Op1");
     Narsese_AtomicTermIndex("Op2");
     //index the copulas as well, to make sure these will have same index on next run
-    for(int i=0; i<(int)strlen(Naresese_CanonicalCopulas); i++)
+    for(int i=0; i<(int)strlen(Narsese_CanonicalCopulas); i++)
     {
-        char cop[2] = { (Naresese_CanonicalCopulas[i]), 0 };
+        char cop[2] = { (Narsese_CanonicalCopulas[i]), 0 };
         Narsese_AtomicTermIndex(cop);
     }
     SELF = Narsese_AtomicTermIndex("SELF");
@@ -760,7 +760,7 @@ Term Narsese_getOperationTerm(Term *term)
     {
         Term potential_operator = Term_ExtractSubterm(term, 2); //(a &/ ^op)
         Term potential_op_seq = {0};
-        if(!Narsese_isOperation(&potential_operator) || !Narsese_OperationSequenceAppendLeftNested(&potential_op_seq, term)) //not an op, or in case there exists a, ^op such that a=(b &/ ^op) (which can happen recursively to b) extrract the op sequence
+        if(!Narsese_isOperation(&potential_operator) || !Narsese_OperationSequenceAppendLeftNested(&potential_op_seq, term)) //not an op, or in case there exists a, ^op such that a=(b &/ ^op) (which can happen recursively to b) extract the op sequence
         {
             return (Term) {0};
         }

--- a/src/Narsese.h
+++ b/src/Narsese.h
@@ -51,7 +51,7 @@ extern char Narsese_atomNames[ATOMS_MAX][ATOMIC_TERM_LEN_MAX];
 extern char Narsese_operatorNames[OPERATIONS_MAX][ATOMIC_TERM_LEN_MAX];
 extern Atom SELF;
 #define Narsese_RuleTableVars "ABCMRSPXYZ"
-#define Naresese_CanonicalCopulas "@*&|;:=$'\"/\\.-%#~+!?^_,"
+#define Narsese_CanonicalCopulas "@*&|;:=$'\"/\\.-%#~+!?^_,"
 #define PRODUCT '*'
 #define EXT_INTERSECTION '&'
 #define INT_INTERSECTION '|'

--- a/src/Shell.c
+++ b/src/Shell.c
@@ -262,7 +262,7 @@ int Shell_ProcessInput(char *line)
             int i = 0;
             while(token != NULL && i < STAMP_SIZE)
             {
-                importstamp.evidentalBase[i++] = strtol(token, NULL, 10);
+                importstamp.evidentialBase[i++] = strtol(token, NULL, 10);
                 token = strtok(NULL, ",");
             }
         }

--- a/src/Stamp.c
+++ b/src/Stamp.c
@@ -33,9 +33,9 @@ Stamp Stamp_make(Stamp *stamp1, Stamp *stamp2)
     {
         if(processStamp1)
         {
-            if(stamp1->evidentalBase[i] != STAMP_FREE)
+            if(stamp1->evidentialBase[i] != STAMP_FREE)
             {
-                ret.evidentalBase[j] = stamp1->evidentalBase[i];
+                ret.evidentialBase[j] = stamp1->evidentialBase[i];
                 j++;
                 if(j >= STAMP_SIZE)
                 {
@@ -49,9 +49,9 @@ Stamp Stamp_make(Stamp *stamp1, Stamp *stamp2)
         }
         if(processStamp2)
         {
-            if(stamp2->evidentalBase[i] != STAMP_FREE)
+            if(stamp2->evidentialBase[i] != STAMP_FREE)
             {
-                ret.evidentalBase[j] = stamp2->evidentalBase[i];
+                ret.evidentialBase[j] = stamp2->evidentialBase[i];
                 j++;
                 if(j >= STAMP_SIZE)
                 {
@@ -75,17 +75,17 @@ bool Stamp_checkOverlap(Stamp *a, Stamp *b)
 {
     for(int i=0;i<STAMP_SIZE;i++)
     {
-        if(a->evidentalBase[i] == STAMP_FREE)
+        if(a->evidentialBase[i] == STAMP_FREE)
         {
             break;
         }
         for(int j=0;j<STAMP_SIZE;j++)
         {
-            if(b->evidentalBase[j] == STAMP_FREE)
+            if(b->evidentialBase[j] == STAMP_FREE)
             {
                 break;
             }
-            if(a->evidentalBase[i] == b->evidentalBase[j])
+            if(a->evidentialBase[i] == b->evidentialBase[j])
             {
                 return true;
             }
@@ -98,18 +98,18 @@ bool Stamp_Equal(Stamp *a, Stamp *b)
 {
     for (int i=0;i<STAMP_SIZE;i++)
     {
-        if (a->evidentalBase[i] == STAMP_FREE)
+        if (a->evidentialBase[i] == STAMP_FREE)
         {
-            return b->evidentalBase[i] == STAMP_FREE;
+            return b->evidentialBase[i] == STAMP_FREE;
         }
         bool contained = false;
         for (int j=0;j<STAMP_SIZE;j++)
         {
-            if (b->evidentalBase[j] == STAMP_FREE)
+            if (b->evidentialBase[j] == STAMP_FREE)
             {
-                return a->evidentalBase[i] == STAMP_FREE;
+                return a->evidentialBase[i] == STAMP_FREE;
             }
-            if (a->evidentalBase[i] == b->evidentalBase[j])
+            if (a->evidentialBase[i] == b->evidentialBase[j])
             {
                 contained = true;
                 break;
@@ -128,17 +128,17 @@ void Stamp_print(Stamp *stamp)
     fputs("Stamp=[", stdout);
     for(int i=0; i<STAMP_SIZE; i++)
     {
-        if(stamp->evidentalBase[i] == STAMP_FREE)
+        if(stamp->evidentialBase[i] == STAMP_FREE)
         {
             break;
         }
-        if(i+1 >= STAMP_SIZE || stamp->evidentalBase[i+1] == STAMP_FREE)
+        if(i+1 >= STAMP_SIZE || stamp->evidentialBase[i+1] == STAMP_FREE)
         {
-            printf("%ld", stamp->evidentalBase[i]);
+            printf("%ld", stamp->evidentialBase[i]);
         }
         else
         {
-            printf("%ld,", stamp->evidentalBase[i]);
+            printf("%ld,", stamp->evidentialBase[i]);
         }
     }
     fputs("]", stdout);

--- a/src/Stamp.h
+++ b/src/Stamp.h
@@ -28,7 +28,7 @@
 /////////////
 //  Stamp  //
 /////////////
-//Keeps track of evidental bases
+//Keeps track of evidential bases
 //This ensures that evidence is only counted once in the conclusions the system makes
 //Design decisions:
 //- Stamps are merged by zipping two existing stamps
@@ -46,15 +46,15 @@
 //Stamp as implemented by all NARS implementations
 #define STAMP_FREE 0
 typedef struct {
-    //EvidentalBase of stamp
-    long evidentalBase[STAMP_SIZE];
+    //EvidentialBase of stamp
+    long evidentialBase[STAMP_SIZE];
 } Stamp;
 
 //Methods//
 //-------//
 //zip stamp1 and stamp2 into a stamp
 Stamp Stamp_make(Stamp *stamp1, Stamp *stamp2);
-//true iff there is evidental base overlap between a and b
+//true iff there is evidential base overlap between a and b
 bool Stamp_checkOverlap(Stamp *a, Stamp *b);
 //Whether two stamps are equal
 bool Stamp_Equal(Stamp *a, Stamp *b);

--- a/src/Truth.c
+++ b/src/Truth.c
@@ -24,18 +24,18 @@
 
 #include "Truth.h"
 
-double TRUTH_EVIDENTAL_HORIZON = TRUTH_EVIDENTAL_HORIZON_INITIAL;
+double TRUTH_EVIDENTIAL_HORIZON = TRUTH_EVIDENTIAL_HORIZON_INITIAL;
 double TRUTH_PROJECTION_DECAY = TRUTH_PROJECTION_DECAY_INITIAL;
 #define TruthValues(v1,v2, f1,c1, f2,c2) double f1 = v1.frequency; double f2 = v2.frequency; double c1 = v1.confidence; double c2 = v2.confidence;
 
 double Truth_w2c(double w)
 {
-    return w / (w + TRUTH_EVIDENTAL_HORIZON);
+    return w / (w + TRUTH_EVIDENTIAL_HORIZON);
 }
 
 double Truth_c2w(double c)
 {
-    return TRUTH_EVIDENTAL_HORIZON * c / (1 - c);
+    return TRUTH_EVIDENTIAL_HORIZON * c / (1 - c);
 }
 
 double Truth_Expectation(Truth v)

--- a/src/Truth.h
+++ b/src/Truth.h
@@ -49,7 +49,7 @@ typedef struct {
 
 //Parameters//
 //----------//
-extern double TRUTH_EVIDENTAL_HORIZON;
+extern double TRUTH_EVIDENTIAL_HORIZON;
 extern double TRUTH_PROJECTION_DECAY;
 #define OCCURRENCE_ETERNAL -1
 #define STRUCTURAL_TRUTH (Truth) { .frequency = 1.0, .confidence = RELIANCE }

--- a/src/Variable.c
+++ b/src/Variable.c
@@ -79,7 +79,7 @@ Substitution Variable_Unify2(Truth truth, Term *general, Term *specific, bool un
                 {
                     return substitution;
                 }
-                if(substitution.map[(int) general_atom].atoms[0] != 0 && !Term_Equal(&substitution.map[(int) general_atom], &subtree)) //unificiation var consistency criteria
+                if(substitution.map[(int) general_atom].atoms[0] != 0 && !Term_Equal(&substitution.map[(int) general_atom], &subtree)) //unification var consistency criteria
                 {
                     return substitution;
                 }

--- a/src/system_tests/Sequence_Test.h
+++ b/src/system_tests/Sequence_Test.h
@@ -87,7 +87,7 @@ void NAR_Sequence_Test()
     NAR_AddInputGoal(Narsese_AtomicTerm("g"));
     assert(op_1_executed && !op_2_executed && !op_3_executed, "Expected op1 execution");
     op_1_executed = op_2_executed = op_3_executed = false;
-    //TODO use "preconditons as operator argument" which then should be equal to (&/,a,b) here
+    //TODO use "preconditions as operator argument" which then should be equal to (&/,a,b) here
     NAR_Cycles(100);
     NAR_AddInputBelief(Narsese_AtomicTerm("b"));
     NAR_AddInputGoal(Narsese_AtomicTerm("g"));
@@ -99,5 +99,5 @@ void NAR_Sequence_Test()
     assert(!op_1_executed && !op_2_executed && op_3_executed, "Expected op3 execution"); //a here
     op_1_executed = op_2_executed = op_3_executed = false;
     MOTOR_BABBLING_CHANCE = MOTOR_BABBLING_CHANCE_INITIAL;
-    puts(">>Sequence Test successul");
+    puts(">>Sequence Test successful");
 }

--- a/src/system_tests/UDPNAR_Test.h
+++ b/src/system_tests/UDPNAR_Test.h
@@ -49,5 +49,5 @@ void NAR_UDPNAR_Test()
     nanosleep((struct timespec[]){{0, timestep}}, NULL); //wait another timestep
     assert(NAR_UDPNAR_Test_op_left_executed, "UDPNAR operation wasn't executed!!");
     UDPNAR_Stop();
-    puts(">>UDPNAR test successul");
+    puts(">>UDPNAR test successful");
 }

--- a/src/unit_tests/HashTable_Test.h
+++ b/src/unit_tests/HashTable_Test.h
@@ -84,5 +84,5 @@ void HashTable_Test()
     HashTable_Set(&HTtest2, blockname, (void*) 42);
     long res = (long) HashTable_Get(&HTtest2, blockname);
     assert(res == 42, "Result is not right!");
-    puts(">>HashTable test successul");
+    puts(">>HashTable test successful");
 }

--- a/src/unit_tests/InvertedAtomIndex_Test.h
+++ b/src/unit_tests/InvertedAtomIndex_Test.h
@@ -63,5 +63,5 @@ void InvertedAtomIndex_Test()
     assert(invertedAtomIndex[Narsese_AtomicTermIndex("b")] == NULL, "Concept reference was not removed for key b! (4)");
     assert(invertedAtomIndex[Narsese_AtomicTermIndex("c")] == NULL, "Concept reference was not removed for key c! (4)");
     assert(invertedAtomIndex[Narsese_AtomicTermIndex("d")] == NULL, "Concept reference was not removed for key d! (4)");
-    puts(">>Inverted atom index test successul");
+    puts(">>Inverted atom index test successful");
 }

--- a/src/unit_tests/Narsese_Test.h
+++ b/src/unit_tests/Narsese_Test.h
@@ -46,7 +46,7 @@ void Narsese_Test()
     puts("Result:");
     Narsese_PrintTerm(&ret);
     puts("");
-    puts(">>Narsese Test successul");
+    puts(">>Narsese Test successful");
     Narsese_PrintTerm(&ret);
     puts("");
 }

--- a/src/unit_tests/RuleTable_Test.h
+++ b/src/unit_tests/RuleTable_Test.h
@@ -29,5 +29,5 @@ void RuleTable_Test()
     NAR_AddInput(Narsese_Term("<cat --> animal>"), EVENT_TYPE_BELIEF, NAR_DEFAULT_TRUTH, true, 0);
     NAR_AddInput(Narsese_Term("<animal --> being>"), EVENT_TYPE_BELIEF, NAR_DEFAULT_TRUTH, true, 0);
     NAR_Cycles(1);
-    puts(">>RuleTable test successul");
+    puts(">>RuleTable test successful");
 }

--- a/src/unit_tests/Stack_Test.h
+++ b/src/unit_tests/Stack_Test.h
@@ -48,5 +48,5 @@ void Stack_Test()
     VMItem *item1_popped_again = Stack_Pop(&stack);
     assert(item1_popped_again->value == &c1, "Popped item1 should point to c1 (2)");
     assert(Stack_IsEmpty(&stack), "Stack should be empty");
-    puts(">>Stack test successul");
+    puts(">>Stack test successful");
 }

--- a/src/unit_tests/Stamp_Test.h
+++ b/src/unit_tests/Stamp_Test.h
@@ -25,9 +25,9 @@
 void Stamp_Test()
 {
     puts(">>Stamp test start");
-    Stamp stamp1 = { .evidentalBase = {1,2} };
+    Stamp stamp1 = { .evidentialBase = {1,2} };
     Stamp_print(&stamp1);
-    Stamp stamp2 = { .evidentalBase = {2,3,4} };
+    Stamp stamp2 = { .evidentialBase = {2,3,4} };
     Stamp_print(&stamp2);
     Stamp stamp3 = Stamp_make(&stamp1, &stamp2);
     fputs("zipped:", stdout);

--- a/src/unit_tests/Table_Test.h
+++ b/src/unit_tests/Table_Test.h
@@ -31,18 +31,18 @@ void Table_Test()
     {
         Implication imp = { .term = Narsese_AtomicTerm("test"), 
                             .truth = { .frequency = 1.0, .confidence = 1.0/((double)(i+1)) },
-                            .stamp = { .evidentalBase = { i } },
+                            .stamp = { .evidentialBase = { i } },
                             .occurrenceTimeOffset = 10,
                             .sourceConcept = &sourceConcept };
         Table_Add(&table, &imp);
     }
     for(int i=0; i<TABLE_SIZE; i++)
     {
-        assert(i+1 == table.array[i].stamp.evidentalBase[0], "Item at table position has to be right");
+        assert(i+1 == table.array[i].stamp.evidentialBase[0], "Item at table position has to be right");
     }
     Implication imp = { .term = Narsese_AtomicTerm("test"), 
                         .truth = { .frequency = 1.0, .confidence = 0.9},
-                        .stamp = { .evidentalBase = { TABLE_SIZE*2+1 } },
+                        .stamp = { .evidentialBase = { TABLE_SIZE*2+1 } },
                         .occurrenceTimeOffset = 10,
                         .sourceConcept = &sourceConcept };
     assert(table.array[0].truth.confidence==0.5, "The highest confidence one should be the first.");

--- a/src/unit_tests/UDP_Test.h
+++ b/src/unit_tests/UDP_Test.h
@@ -48,5 +48,5 @@ void UDP_Test()
     char *send_data = "<(a &/ ^left) =/> g>.";
     UDP_SendData(sockfd_sender, ip, port, send_data, strlen(send_data)+1);
     pthread_join(thread_receiver, NULL);
-    puts(">>UDP test successul");
+    puts(">>UDP test successful");
 }


### PR DESCRIPTION
Typos found and fixed in ONA:

- `Naresese` -> `Narsese`
- `Evidental` -> `Evidential` 
- `unificiation` -> `unification`
- `reaasoner` -> `reasoner`
- `occcurrence` -> `occurrence`
- `perations` -> `operations`
- `Recyle` -> `Recycle`
- `datastructures` -> `data structures`
- `eeach` -> `each`
- `decison` -> `decision`
- `beyound` -> `beyond`
- `subsitution` -> `substitution`
- `cyle` -> `cycle`
- `successul` -> `successful`
- `preconditons` -> `preconditions`

(Referred from The NAL Book, Google, and powered by cspell)

Perhaps these spelling fixes will make future readers less confused :D