### PR TITLE
[small-fix] Unification of inconsistent argument name in `Inference_EventUpdate`

### DIFF
--- a/src/Inference.c
+++ b/src/Inference.c
@@ -111,7 +111,7 @@ Event Inference_GoalDeduction(Event *component, Implication *compound, long curr
                      .creationTime = creationTime };
 }
 
-//{Event a.} |- Event a. updated to currentTime
+//{Event a.} |- Event a. updated to targetTime
 Event Inference_EventUpdate(Event *ev, long targetTime)
 {
     Event ret = *ev;

--- a/src/Inference.h
+++ b/src/Inference.h
@@ -44,8 +44,8 @@
 
 //Methods//
 //-------//
-//{Event a.} |- Event a. Truth_Projection (projecting to current time)
-Event Inference_EventUpdate(Event *ev, long currentTime);
+//{Event a.} |- Event a. Truth_Projection (projecting to target time)
+Event Inference_EventUpdate(Event *ev, long targetTime);
 //{Event a., Event b.} |- Event (a &/ b). Truth_Intersection (after projecting a to b)
 Event Inference_BeliefIntersection(Event *a, Event *b, bool *success);
 //{Event a., Event b.} |- Implication <a =/> b>. Truth_Eternalize(Truth_Induction) (after projecting a to b)


### PR DESCRIPTION
The second argument's name in function `Inference_EventUpdate` declared in [`Inference.h`](https://github.com/opennars/OpenNARS-for-Applications/blob/06f14a32e2df759286b608a2e797a37c00975069/src/Inference.h#L48) and defined in [`Inference.c`](https://github.com/opennars/OpenNARS-for-Applications/blob/06f14a32e2df759286b608a2e797a37c00975069/src/Inference.c#L115) seems inconsistent, which is `currentTime` in `.h` and `targetTime` in `.c`.

Searching for other calls under Inference_EventUpdate, I found that the second argument passed in (such as [here](https://github.com/opennars/OpenNARS-for-Applications/blob/06f14a32e2df759286b608a2e797a37c00975069/src/Inference.c#L151-L152)) is not necessarily "current time" but could be something else.
(Counterexample: Although [`Inference_GoalSequenceDeduction`](https://github.com/opennars/OpenNARS-for-Applications/blob/06f14a32e2df759286b608a2e797a37c00975069/src/Inference.c#L124) and [`Inference_RevisionAndChoice`](https://github.com/opennars/OpenNARS-for-Applications/blob/06f14a32e2df759286b608a2e797a37c00975069/src/Inference.c#L138) use name `currentTime`, all the called places are still passed `currentTime`)

For such cases, perhaps **unifying it to `targetTime`** will make the function signature and definition more consistent and will also reduce confusion for future readers?