### PR TITLE
Append compiler options to ignore compilation warnings that do not have to be displayed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ Str=`ls src/*.c src/NetworkNAR/*.c | xargs`
 echo $Str
 echo "Compilation started:"
 BaseFlags="-flto -g -pthread -lpthread -D_POSIX_C_SOURCE=199506L -pedantic -std=c99 -g3 -O3 $Str -lm -oNAR"
-NoWarn="-Wno-unknown-pragmas -Wno-tautological-compare -Wno-dollar-in-identifier-extension -Wno-unused-parameter -Wno-unused-variable"
+NoWarn="-Wno-unknown-pragmas -Wno-tautological-compare -Wno-dollar-in-identifier-extension -Wno-unused-parameter -Wno-unused-variable -Wno-strict-prototypes"
 gcc $@ -DSTAGE=1 -Wall -Wextra -Wformat-security $NoWarn $BaseFlags
 echo "First stage done, generating RuleTable.c now, and finishing compilation."
 ./NAR NAL_GenerateRuleTable > ./src/RuleTable.c


### PR DESCRIPTION
Appended `-Wno-strict-prototypes` to ignore compilation warnings such like:

When I compiled ONA on my own Termux, I found that it issued a large number of such warnings when compiled with GCC:

```plaintext
In file included from src/Inference.c:25:
  In file included from src/Inference.h:38:
  src/Event.h:66:16: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
     66 | void Event_INIT();
        |                ^
        |                 void
```

Based on my experience with C language and the code situation of ONA, I think such warnings are unnecessary to present to users and can be ignored through compilation options.

After adding `-Wno-strict-prototypes` in Shell variable `NoWarn`, compiling now does not produce any non-fatal warnings.

I tested the new `build.sh` in my Termux again, and now it won't issue a warning on normal compilation:

```bash
~/nars/OpenNARS-for-Applications $ ./build.sh
  src/Cycle.c src/Decision.c src/Event.c src/Globals.c src/HashTable.c src/Inference.c src/InvertedAtomIndex.c src/Memory.c src/NAL.c src/NAR.c src/Nar
  sese.c src/NetworkNAR/Metric.c src/NetworkNAR/UDP.c src/NetworkNAR/UDPNAR.c src/OccurrenceTimeIndex.c src/PriorityQueue.c src/Shell.c src/Stack.c src
  /Stamp.c src/Stats.c src/Table.c src/Term.c src/Truth.c src/Usage.c src/Variable.c src/main.c
  Compilation started:
  First stage done, generating RuleTable.c now, and finishing compilation.
  gcc: error: unsupported option '-msse2' for target 'aarch64-unknown-linux-android24'
  Error with SSE, hence compiling without SSE:
  Done.                                                                                                                                                  ~/nars/OpenNARS-for-Applications $
```