### PR TITLE
Update: Narsese.c: simplify its dependency on `NAR.h` to `HashTable.h` more accurately

### DIFF
--- a/src/Narsese.c
+++ b/src/Narsese.c
@@ -23,7 +23,7 @@
  */
 
 #include "Narsese.h"
-#include "NAR.h"
+#include "HashTable.h"
 
 //Atomic term values:
 double Narsese_atomValues[ATOMS_MAX];


### PR DESCRIPTION
While building Graphviz dependency graph for ONA, I found that `Narsese.c` seems to be abnormally dependent on `NAR.h`, which is more like ONA's high-level function (on top of knowledge representation language and inference logic).

Based on what I've learned about `Narsese.c` in recent days, I think it probably doesn't have to rely on such a high level of definition and can only rely on `HashTable.h` functionally for "mapping from string to id of atom".

I tried to comment out `#include "NAR.h"` and re-run `build.sh` and found that the error was indeed `HashTable` related:

```bash
~/nars/OpenNARS-for-Applications $ ./build.sh
rm: cannot remove 'NAR': No such file or directory
rm: cannot remove 'src/RuleTable.c': No such file or directory
src/Cycle.c src/Decision.c src/Event.c src/Globals.c src/HashTable.c src/Inference.c src/InvertedAtomIndex.c src/Memory.c src/NAL.c src/NAR.c src/Narsese.c src/NetworkNAR/Metric.c src/NetworkNAR/UDP.c src/NetworkNAR/UDPNAR.c src/OccurrenceTimeIndex.c src/PriorityQueue.c src/Shell.c src/Stack.c src/Stamp.c src/Stats.c src/Table.c src/Term.c src/Truth.c src/Usage.c src/Variable.c src/main.c
Compilation started:
src/Narsese.c:295:1: error: unknown type name 'HashTable'
  295 | HashTable HTatoms;
      | ^
src/Narsese.c:296:1: error: unknown type name 'VMItem'
  296 | VMItem* HTatoms_storageptrs[ATOMS_MAX];
      | ^
src/Narsese.c:297:1: error: unknown type name 'VMItem'
  297 | VMItem HTatoms_storage[ATOMS_MAX];
      | ^
src/Narsese.c:298:1: error: unknown type name 'VMItem'
  298 | VMItem* HTatoms_HT[ATOMS_HASHTABLE_BUCKETS];
      | ^
src/Narsese.c:307:20: error: call to undeclared function 'HashTable_Get'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  307 |     void* retptr = HashTable_Get(&HTatoms, blockname);
      |                    ^
src/Narsese.c:317:9: error: call to undeclared function 'HashTable_Set'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  317 |         HashTable_Set(&HTatoms, (void*) Narsese_atomNames[term_index], (void*) ret_index);
      |         ^
src/Narsese.c:373:5: error: call to undeclared function 'Variable_Normalize'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  373 |     Variable_Normalize(&ret);
      |     ^
src/Narsese.c:664:5: error: call to undeclared function 'HashTable_INIT'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  664 |     HashTable_INIT(&HTatoms, HTatoms_storage, HTatoms_storageptrs, HTatoms_HT, ATOMS_HASHTABLE_BUCKETS, ATOMS_MAX, (Equal) Narsese_StringEqual, (Hash) Narsese_StringHash);
      |     ^
src/Narsese.c:664:117: error: use of undeclared identifier 'Equal'
  664 |     HashTable_INIT(&HTatoms, HTatoms_storage, HTatoms_storageptrs, HTatoms_HT, ATOMS_HASHTABLE_BUCKETS, ATOMS_MAX, (Equal) Narsese_StringEqual, (Hash) Narsese_StringHash);
      |                                                                                                                     ^
src/Narsese.c:664:146: error: use of undeclared identifier 'Hash'
  664 |     HashTable_INIT(&HTatoms, HTatoms_storage, HTatoms_storageptrs, HTatoms_HT, ATOMS_HASHTABLE_BUCKETS, ATOMS_MAX, (Equal) Narsese_StringEqual, (Hash) Narsese_StringHash);
      |                                                                                                                                                  ^
src/Narsese.c:727:107: error: call to undeclared function 'Variable_isVariable'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  727 |     return Narsese_isOperation(term) && (Narsese_isOperator(term->atoms[0]) || (term->atoms[7] == SELF || Variable_isVariable(term->atoms[7])));
      |                                                                                                           ^
11 errors generated.
```

Then I changed `#include "NAR.h"` to `#include "HashTable.h"` and ran `build.sh` again, ONA compiled successfully and passed its tests normally.