### PR TITLE
Refine：removal of unused variables

### DIFF
--- a/src/Memory.h
+++ b/src/Memory.h
@@ -67,7 +67,6 @@ typedef struct
     Term arguments[OPERATIONS_BABBLE_ARGS_MAX];
     bool stdinOutput;
 }Operation;
-extern bool ontology_handling;
 extern Event selectedBeliefs[BELIEF_EVENT_SELECTIONS]; //better to be global
 extern double selectedBeliefsPriority[BELIEF_EVENT_SELECTIONS]; //better to be global
 extern int beliefsSelectedCnt;

--- a/src/Memory.h
+++ b/src/Memory.h
@@ -48,7 +48,6 @@
 //----------//
 //Inferences per cycle (amount of events from cycling events)
 extern bool RESTRICTED_CONCEPT_CREATION;
-extern double PROPAGATION_THRESHOLD;
 extern bool PRINT_DERIVATIONS;
 extern bool PRINT_INPUT;
 extern double conceptPriorityThreshold;

--- a/src/unit_tests/OccurrenceTimeIndex_Test.h
+++ b/src/unit_tests/OccurrenceTimeIndex_Test.h
@@ -27,7 +27,6 @@ void OccurrenceTimeIndex_Test()
     puts(">>OccurrenceTimeIndex test start");
     OccurrenceTimeIndex fifo = {0};
     //First, evaluate whether the fifo works, not leading to overflow
-    int occurrence = 0;
     for(int i=OCCURRENCE_TIME_INDEX_SIZE*2; i>=1; i--) //"rolling over" once by adding a k*FIFO_Size items
     {
         Concept *c1 = (Concept*) (long) i;


### PR DESCRIPTION
Here are some of the unused variables I found in `OccurrenceTimeIndex_Test.h` and `Memory.h`, which may be outdated or confusing to later readers (because they don't know where it will be used).

I keep track of these unused variables in this branch and provide a commit of removal on each of them to facilitate cherry picking or providing further explanations.

I'll keep track of other unused variables during my work :)