### PR TITLE
Attempt to eliminate cyclic dependency `NAR→Cycle→Decision`

### DIFF
--- a/src/Cycle.c
+++ b/src/Cycle.c
@@ -154,7 +154,7 @@ void Cycle_PopEvents(Event *selectionArray, double *selectionPriority, int *sele
 //{Event (a &/ b)!, Event a.} |- Event b! Truth_Deduction
 //if Truth_Expectation(a) >= ANTICIPATION_THRESHOLD else
 //{Event (a &/ b)!} |- Event a! Truth_StructuralDeduction
-bool Cycle_GoalSequenceDecomposition(Event *selectedGoal, double selectedGoalPriority, int layer)
+bool Cycle_GoalSequenceDecomposition(Event *selectedGoal, double selectedGoalPriority, int layer, long currentTime)
 {
     //1. Extract potential subgoals
     if(!Narsese_copulaEquals(selectedGoal->term.atoms[0], SEQUENCE)) //left-nested sequence
@@ -276,7 +276,7 @@ static void Cycle_ProcessAndInferGoalEvents(long currentTime, int layer)
         Event *goal = &selectedGoals[i];
         IN_DEBUG( fputs("selected goal ", stdout); Narsese_PrintTerm(&goal->term); puts(""); )
         //if goal is a sequence, overwrite with first deduced non-fulfilled element
-        if(Cycle_GoalSequenceDecomposition(goal, selectedGoalsPriority[i], layer)) //the goal was a sequence which leaded to a subgoal derivation
+        if(Cycle_GoalSequenceDecomposition(goal, selectedGoalsPriority[i], layer, currentTime)) //the goal was a sequence which leaded to a subgoal derivation
         {
             continue;
         }
@@ -340,7 +340,7 @@ static void Cycle_ProcessAndInferGoalEvents(long currentTime, int layer)
 }
 
 //Reinforce temporal implication link between a's and b's concept (via temporal induction)
-static Implication Cycle_ReinforceLink(Event *a, Event *b)
+static Implication Cycle_ReinforceLink(Event *a, Event *b, long currentTime)
 {
     if(a->type != EVENT_TYPE_BELIEF || b->type != EVENT_TYPE_BELIEF)
     {
@@ -416,7 +416,7 @@ void Cycle_ProcessBeliefEvents(long currentTime)
                                 //so now derive it
                                 if(success5)
                                 {
-                                    Cycle_ReinforceLink(&seq_op_cur, &postcondition); //<(A &/ op) =/> B>
+                                    Cycle_ReinforceLink(&seq_op_cur, &postcondition, currentTime); //<(A &/ op) =/> B>
                                 }
                             }
                         }
@@ -445,10 +445,10 @@ void Cycle_ProcessBeliefEvents(long currentTime)
                         {
                             if(!op_id && !op_id2)
                             {
-                                Cycle_ReinforceLink(&c->belief_spike, &postcondition); //<A =/> B>, <A =|> B>
+                                Cycle_ReinforceLink(&c->belief_spike, &postcondition, currentTime); //<A =/> B>, <A =|> B>
                                 if(c->belief_spike.occurrenceTime == postcondition.occurrenceTime)
                                 {
-                                    Cycle_ReinforceLink(&postcondition, &c->belief_spike); //<B =|> A>
+                                    Cycle_ReinforceLink(&postcondition, &c->belief_spike, currentTime); //<B =|> A>
                                 }
                             }
                             int sequence_len = 0;

--- a/src/Decision.c
+++ b/src/Decision.c
@@ -284,7 +284,7 @@ static Decision Decision_MotorBabbling()
     return decision;
 }
 
-static Decision Decision_ConsiderNegativeOutcomes(Decision decision)
+static Decision Decision_ConsiderNegativeOutcomes(Decision decision, long currentTime)
 {
     Event OpGoalImmediateOutcomes = {0};
     //1. discount decision based on negative outcomes via revision
@@ -386,7 +386,7 @@ static Decision Decision_ConsiderImplication(long currentTime, Event *goal, Impl
             i++;
         }
     }
-    return Decision_ConsiderNegativeOutcomes(decision);
+    return Decision_ConsiderNegativeOutcomes(decision, currentTime);
 }
 
 Decision Decision_BestCandidate(Concept *goalconcept, Event *goal, long currentTime)

--- a/src/Decision.h
+++ b/src/Decision.h
@@ -51,7 +51,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include "Memory.h"
-#include "NAR.h"
 #include "Config.h"
 
 //Parameters//

--- a/src/NAR.c
+++ b/src/NAR.c
@@ -24,7 +24,7 @@
 
 #include "NAR.h"
 
-long currentTime = 1;
+static long currentTime = 1; //This needs to be private to encourage the design of "pass in parameters rather than using global variables"
 static bool initialized = false;
 static int op_k = 0;
 double QUESTION_PRIMING = QUESTION_PRIMING_INITIAL;

--- a/src/NAR.h
+++ b/src/NAR.h
@@ -41,7 +41,6 @@
 //Parameters//
 //----------//
 #define NAR_DEFAULT_TRUTH ((Truth) { .frequency = NAR_DEFAULT_FREQUENCY, .confidence = NAR_DEFAULT_CONFIDENCE })
-extern long currentTime;
 extern double QUESTION_PRIMING;
 
 //Callback function types//


### PR DESCRIPTION
Maybe reducing cyclic dependency can make the module dependency of ONA better?

- Privatize the global variable currentTime in `NAR.c` - completely possible
- Supplement the parameter `currentTime` of `Decision_ConsiderNegativeOutcomes` to eliminate the cyclic dependency of `NAR` -> `Cycle` -> `Decision` - still WIP and needs further discussions

The only problem is here:

https://github.com/opennars/OpenNARS-for-Applications/blob/9954416ca1316bdb42ffe6c8e65b339c0c54ca95/src/Decision.c#L230

Are there any good alternatives to "input beliefs"?
Pass a function pointer such like `void (*InputBelief) (Term)` as a parameter on `Decision_Execute`, `Cycle_ProcessAndInferGoalEvents` and `Cycle_Perform`?