### PR TITLE
`NAL.c`: Correcting duplicate conditions that are not changed after coping

### DIFF
--- a/src/NAL.c
+++ b/src/NAL.c
@@ -311,7 +311,7 @@ static bool NAL_IndepOrDepVariableAppearsOnce(Term *conclusionTerm)
 {
     for(int i=0; i<COMPOUND_TERM_SIZE_MAX; i++)
     {
-        if(Variable_isDependentVariable(conclusionTerm->atoms[i]) || Variable_isDependentVariable(conclusionTerm->atoms[i]))
+        if(Variable_isIndependentVariable(conclusionTerm->atoms[i]) || Variable_isDependentVariable(conclusionTerm->atoms[i]))
         {
             for(int j=0; j<COMPOUND_TERM_SIZE_MAX; j++)
             {


### PR DESCRIPTION
The code with issues is here:

https://github.com/opennars/OpenNARS-for-Applications/blob/f0f5a7ef04c97852d4d1d3e3f7efa3f6e294e546/src/NAL.c#L310-L319

Focusing on Line 314:

https://github.com/opennars/OpenNARS-for-Applications/blob/f0f5a7ef04c97852d4d1d3e3f7efa3f6e294e546/src/NAL.c#L314

According to the name of function `NAL_IndepOrDepVariableAppearsOnce` (independent or dependent variable appears once),
Perhaps this repeated condition should be revised to "Indep+Dep" form?