### PR TITLE
`Memory.h`: Removal of outdated function declaration

### DIFF
--- a/src/Memory.h
+++ b/src/Memory.h
@@ -101,8 +101,6 @@ Concept* Memory_Conceptualize(Term *term, long currentTime);
 //Add event to memory
 void Memory_AddEvent(Event *event, long currentTime, double priority, bool input, bool derived, bool revised, int layer);
 void Memory_AddInputEvent(Event *event, long currentTime);
-//Add operation to memory
-void Memory_AddOperation(int id, Operation op);
 //check if implication is still valid (source concept might be forgotten)
 bool Memory_ImplicationValid(Implication *imp);
 //Print an event in memory:


### PR DESCRIPTION
Removed outdated function declaration `Memory_AddOperation`, which was superseded by `NAR_AddOperation`

This is related to #279 