### PR TITLE
[small-fix] `NAR`: Unification of inconsistent argument name in `NAR_AddOperation`

### DIFF
--- a/src/NAR.c
+++ b/src/NAR.c
@@ -76,12 +76,12 @@ Event NAR_AddInputGoal(Term term)
     return NAR_AddInput(term, EVENT_TYPE_GOAL, NAR_DEFAULT_TRUTH, false, 0);
 }
 
-void NAR_AddOperation(char *term_name, Action procedure)
+void NAR_AddOperation(char *operator_name, Action procedure)
 {
     assert(procedure != 0, "Cannot add an operation with null-procedure");
     assert(initialized, "NAR not initialized yet, call NAR_INIT first!");
-    Term term = Narsese_AtomicTerm(term_name);
-    assert(term_name[0] == '^', "This atom does not belong to an operator!");
+    Term term = Narsese_AtomicTerm(operator_name);
+    assert(operator_name[0] == '^', "This atom does not belong to an operator!");
     //check if term already exists
     int existing_k = Memory_getOperationID(&term);
     //use the running k if not existing yet

--- a/src/NAR.h
+++ b/src/NAR.h
@@ -59,7 +59,7 @@ Event NAR_AddInput(Term term, char type, Truth truth, bool eternal, double occur
 Event NAR_AddInputBelief(Term term);
 Event NAR_AddInputGoal(Term term);
 //Add an operation
-void NAR_AddOperation(char *atomname, Action procedure);
+void NAR_AddOperation(char *operator_name, Action procedure);
 //Add an Narsese sentence:
 void NAR_AddInputNarsese(char *narsese_sentence);
 //Add an Narsese sentence with query functionality for questions:


### PR DESCRIPTION
Names unified: `atomname` | `term_name` -> `operator_name`

In the function `NAR_AddOperation`, here ONA actually adds a new operator whose name is required an atomic term (such like `^left` to support compound operation `<({SELF} * ARG) --> ^left>`).
Depending on the actual usage of the parameter, perhaps it would be more accurate to unify the name to `operator_name`?