### PR TITLE
[build] New script `build.cmd` for compilation on Windows

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -2,8 +2,8 @@
 setlocal enabledelayedexpansion
 
 :: delete NAR and src\RuleTable.c
-del NAR
-del src\RuleTable.c
+del .\NAR.exe
+del .\src\RuleTable.c
 
 :: setup error handling
 set ERRORLEVEL=0

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,57 @@
+@echo off
+setlocal enabledelayedexpansion
+
+:: delete NAR and src\RuleTable.c
+del NAR
+del src\RuleTable.c
+
+:: setup error handling
+set ERRORLEVEL=0
+
+:: get all .c file path
+for /r "src" %%f in (*.c) do (
+    set "Str=!Str! %%f"
+)
+
+:: print all .c file path and notify user the compilation is started
+echo !Str!
+echo Compilation started:
+
+:: setup compiler parameters of gcc
+set BaseFlags=-flto -g -pthread -lpthread -D_POSIX_C_SOURCE=199506L -pedantic -std=c99 -g3 -O3 !Str! -lm -oNAR
+
+:: mute the output of compiler warnings
+set NoWarn=-Wno-unknown-pragmas -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-variable -Wno-strict-prototypes -Wno-implicit-function-declaration -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast
+
+:: 1st stage compilation
+gcc %* -DSTAGE=1 -Wall -Wextra -Wformat-security %NoWarn% %BaseFlags%
+
+:: check if compilation was successful
+if %ERRORLEVEL% neq 0 (
+    echo Error during first stage compilation.
+    goto :eof
+)
+
+:: notify user that 1st stage is done, and start generating RuleTable.c
+echo First stage done, generating RuleTable.c now, and finishing compilation.
+
+:: generate RuleTable.c uses 1st stage binary
+call NAR.exe NAL_GenerateRuleTable > src\RuleTable.c
+
+:: try second stage compilation with SSE flag
+gcc %* -mfpmath=sse -msse2 -DSTAGE=2 %NoWarn% %BaseFlags% src\RuleTable.c
+if %ERRORLEVEL% equ 0 (
+    echo Done.
+) else (
+    echo Error with SSE, hence compiling without SSE:
+    :: if error, try compilation without SSE:
+    gcc %* -DSTAGE=2 %NoWarn% %BaseFlags% src\RuleTable.c
+    if %ERRORLEVEL% equ 0 (
+        echo Done.
+    ) else (
+        echo Compilation failed.
+    )
+)
+
+:end
+endlocal


### PR DESCRIPTION
## Feature

Translated shell script `build.cmd` for Windows
- Aiming to build `NAR.exe`
- Changed variable `NoWarn` to fit the platform environments
  - +`-Wno-implicit-function-declaration -Wno-pointer-to-int-cast -Wno-int-to-pointer-cast`
  - -`-Wno-dollar-in-identifier-extension`

## Environment of testing
- Windows version: Windows 11
- GCC version: gcc (x86_64-posix-seh) 12.2.0
- GCC source: MinGW
- Terminal: CMD, PowerShell
- Compilation target: `.\NAR.exe`

## Previews

### Compilation on Terminal

CMD & PowerShell:

![CMD&PowerShell](https://github.com/user-attachments/assets/8bd33104-7ab6-4b59-92b6-949d7ef7ff9e)

### Runtime

![ONA Running](https://github.com/user-attachments/assets/7523a907-6146-43d4-964f-1985742a5f26)