### PR TITLE
New feature of displaying `OccurrenceTimeIndex`

### DIFF
--- a/src/OccurrenceTimeIndex.c
+++ b/src/OccurrenceTimeIndex.c
@@ -54,3 +54,13 @@ Concept* OccurrenceTimeIndex_GetKthNewestElement(OccurrenceTimeIndex *fifo, int 
     return fifo->array[OccurrenceTimeIndex_Index(fifo, k)];
 }
 
+void OccurrenceTimeIndex_Print(OccurrenceTimeIndex *fifo) {
+    puts("printing occurrence time index content:");
+    for (int k = 0; k < fifo->itemsAmount; k++) {
+        Concept* elem = OccurrenceTimeIndex_GetKthNewestElement(fifo, k);
+        printf("%d: ", k);
+        Narsese_PrintTerm(&elem->term);
+        puts("");
+    }
+    puts("index print finish");
+}

--- a/src/OccurrenceTimeIndex.h
+++ b/src/OccurrenceTimeIndex.h
@@ -52,5 +52,7 @@ typedef struct
 void OccurrenceTimeIndex_Add(Concept *concept, OccurrenceTimeIndex *fifo);
 //Get the k-th newest OccurrenceTimeIndex element
 Concept* OccurrenceTimeIndex_GetKthNewestElement(OccurrenceTimeIndex *fifo, int k);
+//Print the occurrence time index
+void OccurrenceTimeIndex_Print(OccurrenceTimeIndex *fifo);
 
 #endif

--- a/src/Shell.c
+++ b/src/Shell.c
@@ -131,6 +131,10 @@ int Shell_ProcessInput(char *line)
         {
             InvertedAtomIndex_Print();
         }
+        if(!strcmp(line,"*occurrence_time_index"))
+        {
+            OccurrenceTimeIndex_Print(&occurrenceTimeIndex);
+        }
         else
         if(!strcmp(line,"*opconfig"))
         {


### PR DESCRIPTION
## New Features

- Added a function `Print` for displaying `OccurrenceTimeIndex`
- Added corresponding command `*occurrence_time_index` to the ONA Shell

## Preview

```terminal
[...]> ./NAR shell

a. :|:
Input: a. :|: occurrenceTime=1 Priority=1.000000 Stamp=[1] Truth: frequency=1.000000, confidence=0.900000

b. :|:
Input: b. :|: occurrenceTime=2 Priority=1.000000 Stamp=[2] Truth: frequency=1.000000, confidence=0.900000

c. :|:
Input: c. :|: occurrenceTime=3 Priority=1.000000 Stamp=[3] Truth: frequency=1.000000, confidence=0.900000

*occurrence_time_index
printing occurrence time index content:
0: (a &/ c)
1: (b &/ c)
2: ((a &/ b) &/ c)
3: c
4: (a &/ b)
5: b
6: a
index print finish
```